### PR TITLE
Allowing for option of splunk hec ssl or non ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Running the Fabric Logger in Docker is recommended. A sample docker-compose entr
                 - FABRIC_MSP=<msp name>
                 - FABRIC_PEER=peer0.example.com
                 - SPLUNK_HEC_TOKEN=12345678-ABCD-EFGH-IJKL-123456789012
-                - SPLUNK_HOST=splunk.example.com
-                - SPLUNK_PORT=8088
+                - SPLUNK_HEC_URL=https://splunk.example.com:8088
                 - SPLUNK_INDEX=hyperledger_logs
                 - LOGGING_LOCATION=splunk
                 - NETWORK_CONFIG=network.yaml
@@ -72,8 +71,7 @@ We also include a helm chart for Kubernetes deployments. First set your `values.
     splunk:
         hec:
             token: 12345678-ABCD-EFGH-IJKL-123456789012
-            port: 8088
-            host: splunk-splunk-kube.splunk.svc.cluster.local
+            url: https://splunk-splunk-kube.splunk.svc.cluster.local:8088
         index: hyperledger_logs
 
     secrets:
@@ -152,8 +150,9 @@ You will also need to update the `network.yaml` with appropriate values for you 
 | FABRIC_PEER            | The hostname of the peer to connect to.                                                                                                                  | None (Required)    |
 | LOGGING_LOCATION       | The logging location, valid values are `splunk` or `stdout`.                                                                                             | `splunk`           |
 | SPLUNK_HEC_TOKEN       | If using `splunk` as the logging location, the HEC token value.                                                                                          | None               |
-| SPLUNK_HOST            | Splunk hostname.                                                                                                                                         | None               |
-| SPLUNK_PORT            | Splunk HEC port.                                                                                                                                         | `8088`             |
+| SPLUNK_HEC_URL         | If using `splunk` as the logging location, the url to the splunk instance event collector.                                                               | None               |
+| SPLUNK_HOST  DEPRECATED| Splunk hostname. DEPRECATED Please use SPLUNK_HEC_URL.                                                                                                   | None               |
+| SPLUNK_PORT  DEPRECATED| Splunk HEC port. DEPRECATED Please use SPLUNK_HEC_URL.                                                                                                   | `8088`             |
 | SPLUNK_INDEX           | Splunk index to log to.                                                                                                                                  | `hyperledger_logs` |
 | NETWORK_CONFIG         | A network configuration object, an example can be found [here](https://fabric-sdk-node.github.io/release-1.4/tutorial-network-config.html)               | None (Required)    |
 | CHECKPOINTS_FILE       | A file used to hold checkpoints for each channel watched. If running in docker, be sure to mount a volume so that the file is not lost between restarts. | `.checkpoints`     |

--- a/helm-chart/fabric-logger/Chart.yaml
+++ b/helm-chart/fabric-logger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v1.2.0"
+appVersion: "v1.2.1"
 description: A Helm chart for Splunk Connect for Hyperledger Fabric
 name: fabric-logger
-version: v1.2.0
+version: v1.2.1
 keywords:
   - blockchain
   - hyperledger

--- a/helm-chart/fabric-logger/templates/deployment.yaml
+++ b/helm-chart/fabric-logger/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             value: {{ .Values.peer.username | quote }}
           - name: SPLUNK_HEC_TOKEN
             value: {{ .Values.splunk.hec.token | quote }}
+          - name: SPLUNK_HEC_URL
+            value: {{ .Values.splunk.hec.url | quote }}
           - name: SPLUNK_HOST
             value: {{ .Values.splunk.hec.host | quote }}
           - name: SPLUNK_PORT

--- a/helm-chart/fabric-logger/values.yaml
+++ b/helm-chart/fabric-logger/values.yaml
@@ -50,8 +50,7 @@ loggingLocation: splunk
 splunk:
   hec:
     token: 00000000-0000-0000-0000-000000000000
-    port: 8088
-    host: splunk.example.com
+    url: https://splunk.example.com:8088
   index: hyperledger_logs
 
 ingress:

--- a/helm-chart/fabric-logger/values.yaml
+++ b/helm-chart/fabric-logger/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: splunkdlt/fabric-logger
-  tag: release-1.1.1
+  tag: latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric-logger",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Hyperledger Fabric Splunk integration",
   "author": "Jeff Wu <jeffreywu@splunk.com>",
   "main": "dist/index.js",

--- a/src/env.ts
+++ b/src/env.ts
@@ -62,11 +62,11 @@ export function initializeEnvironment() {
             checkRequiredEnvVar(SPLUNK_HEC_URL, 'SPLUNK_HEC_URL');
         } else {
             checkRequiredEnvVar(SPLUNK_HOST, 'SPLUNK_HOST');
-            checkRequiredEnvVar(SPLUNK_HEC_TOKEN, 'SPLUNK_HEC_TOKEN');
             if (SPLUNK_PORT % 1 !== 0 || SPLUNK_PORT < 1 || SPLUNK_PORT > 65535) {
                 throw new Error(`Invalid SPLUNK_PORT value specified - needs to be a valid port number`);
             }
         }
+        checkRequiredEnvVar(SPLUNK_HEC_TOKEN, 'SPLUNK_HEC_TOKEN');
     }
     checkRequiredEnvVar(FABRIC_PEER, 'FABRIC_PEER');
     checkRequiredEnvVar(FABRIC_MSP, 'FABRIC_MSP');

--- a/src/env.ts
+++ b/src/env.ts
@@ -20,10 +20,12 @@ export const LOGGING_LOCATION: 'splunk' | 'stdout' | 'file' =
     process.env.LOGGING_LOCATION === 'stdout' ? 'stdout' : process.env.LOGGING_LOCATION === 'file' ? 'file' : 'splunk';
 /** A file used to hold checkpoints for each channel watched. If running in docker, be sure to mount a volume so that the file is not lost between restarts */
 export const CHECKPOINTS_FILE: string = process.env.CHECKPOINTS_FILE || '.checkpoints';
-/** Splunk hostname */
+/** DEPRECATED Splunk hostname */
 export const SPLUNK_HOST: string = process.env.SPLUNK_HOST!;
-/** Splunk HEC port */
+/** DEPRECATED Splunk HEC port */
 export const SPLUNK_PORT: number = parseNumber(process.env.SPLUNK_PORT) || 8088;
+/** If using `splunk` as the logging location, the URL to splunk instance event collector */
+export const SPLUNK_HEC_URL: string = process.env.SPLUNK_HEC_URL!;
 /** If using `splunk` as the logging location, the HEC token value */
 export const SPLUNK_HEC_TOKEN: string = process.env.SPLUNK_HEC_TOKEN!;
 /** Splunk index to log to */
@@ -56,10 +58,14 @@ export function checkRequiredEnvVar(val: string | undefined, variable: string): 
 
 export function initializeEnvironment() {
     if (LOGGING_LOCATION === 'splunk') {
-        checkRequiredEnvVar(SPLUNK_HOST, 'SPLUNK_HOST');
-        checkRequiredEnvVar(SPLUNK_HEC_TOKEN, 'SPLUNK_HEC_TOKEN');
-        if (SPLUNK_PORT % 1 !== 0 || SPLUNK_PORT < 1 || SPLUNK_PORT > 65535) {
-            throw new Error(`Invalid SPLUNK_PORT value specified - needs to be a valid port number`);
+        if (SPLUNK_HEC_URL != null) {
+            checkRequiredEnvVar(SPLUNK_HEC_URL, 'SPLUNK_HEC_URL');
+        } else {
+            checkRequiredEnvVar(SPLUNK_HOST, 'SPLUNK_HOST');
+            checkRequiredEnvVar(SPLUNK_HEC_TOKEN, 'SPLUNK_HEC_TOKEN');
+            if (SPLUNK_PORT % 1 !== 0 || SPLUNK_PORT < 1 || SPLUNK_PORT > 65535) {
+                throw new Error(`Invalid SPLUNK_PORT value specified - needs to be a valid port number`);
+            }
         }
     }
     checkRequiredEnvVar(FABRIC_PEER, 'FABRIC_PEER');

--- a/src/fabric.ts
+++ b/src/fabric.ts
@@ -243,11 +243,7 @@ export const processChaincodeEvent = (channelName: string) => (
     );
 };
 
-export async function registerChaincodeEvent(
-    channelName: string,
-    chaincodeId: string,
-    filter: string
-): Promise<void> {
+export async function registerChaincodeEvent(channelName: string, chaincodeId: string, filter: string): Promise<void> {
     if (client == null) {
         throw new Error('Fabric client not initialized');
     }

--- a/src/output.ts
+++ b/src/output.ts
@@ -4,6 +4,7 @@ import {
     SPLUNK_HEC_TOKEN,
     SPLUNK_HOST,
     SPLUNK_PORT,
+    SPLUNK_HEC_URL,
     FABRIC_PEER,
     SOURCETYPE_PREFIX,
     SPLUNK_INDEX,
@@ -65,7 +66,9 @@ export async function writeEventToFile(event: SendContext) {
 export function initializeLogOutput() {
     switch (LOGGING_LOCATION) {
         case 'splunk':
-            const url = 'https://' + SPLUNK_HOST + ':' + SPLUNK_PORT;
+            // Maintain Backwards compatibility with previous versions of fabric logger that used SPLUNK_HOST and PORT without specifying SSL
+            // See https://github.com/splunk/fabric-logger/issues/32
+            const url = SPLUNK_HEC_URL != null ? SPLUNK_HEC_URL : `https://${SPLUNK_HOST}:${SPLUNK_PORT}`;
             currentLogger = new SplunkLogger({ token: SPLUNK_HEC_TOKEN, url });
             (currentLogger as any).eventFormatter = (event: any): any => event;
             info(`Using Splunk HEC at ${url}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,9 +60,9 @@ app.put('/channels/:channel', async (req, res) => {
 app.put('/channels/:channel/events/:ccid', async (req, res) => {
     const channel = req.params['channel'];
     const ccid = req.params['ccid'];
-    if (!req.body.filter){
-        res.status(400)
-        res.send('Failed to register Chaincode event listener.  Request requires filter parameter in body')
+    if (!req.body.filter) {
+        res.status(400);
+        res.send('Failed to register Chaincode event listener.  Request requires filter parameter in body');
     }
     const filter = req.body.filter.toString();
     const name = `${channel}_${ccid}_${filter}`;


### PR DESCRIPTION
fixes bug #32 

Should be backwards compatible with those still using splunk_host and splunk_port values.  This allows people to specify if they want http or https for their event collector.