### PR TITLE
Updating fabric-logger to use fabric-network and support private data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ As Fabric Logger processes blocks and chaincode events the progress is stored in
 myChannel=5
 mySecondChannel=3
 
-[ccevents.myChannel_myChaincodeId_myRegexFilter]
+[ccevents.myChannel_myChaincodeId]
 channelName=myChannel
-filter=myRegexFilter
 chaincodeId=myChaincodeId
 block=5
 ```
@@ -47,14 +46,13 @@ Running the Fabric Logger in Docker is recommended. A sample docker-compose entr
     services:
         fabric-logger.example.com:
             container_name: fabric-logger.example.com
-            image: splunkdlt/fabric-logger:release-2.0.2
+            image: splunkdlt/fabric-logger:release-3.0.0
             environment:
                 - FABRIC_KEYFILE=<path to private key file>
                 - FABRIC_CERTFILE=<path to signed certificate>
                 - FABRIC_CLIENT_CERTFILE=<path to client certificate when using mutual tls>
                 - FABRIC_CLIENT_KEYFILE=<path to client private key when using mutual tls>
                 - FABRIC_MSP=<msp name>
-                - FABRIC_PEER=peer0.example.com
                 - SPLUNK_HEC_TOKEN=12345678-ABCD-EFGH-IJKL-123456789012
                 - SPLUNK_HEC_URL=https://splunk.example.com:8088
                 - SPLUNK_HEC_REJECT_INVALID_CERTS="false"
@@ -79,13 +77,14 @@ Running the Fabric Logger in Docker is recommended. A sample docker-compose entr
 
 We also include a helm chart for Kubernetes deployments. First set your `values.yaml` file. Here is an example configuration (although this will be specific to your environment):
 
-    peer:
-        mspName: PeerMSP
-        peerName: peer0
-        username: admin
-        peerAddress: peer0.example.com
-        channels:
-            - mychannel
+    peers:
+        peer0:
+            mspName: PeerMSP
+            peerName: peer0
+            username: admin
+            peerAddress: peer0.example.com
+            channels:
+                - mychannel
 
     splunk:
         hec:
@@ -103,10 +102,8 @@ We also include a helm chart for Kubernetes deployments. First set your `values.
         - channel2
     ccevents:
         - channelName: channel1
-          filter: myEvent
           chaincodeId: myChaincodeId
         - channelName: channel1
-          filter: myOtherEvent
           chaincodeId: myChaincodeId
 
 ### Kubernetes: Autogenerating Secrets
@@ -145,7 +142,7 @@ A `network.yaml` will automatically be generated using the secrets and channel d
 
     helm install -n fabric-logger-${PEER_NAME}-${NS} --namespace ${NS} \
                  -f values.yaml \
-                 https://github.com/splunk/fabric-logger/releases/download/v2.0.2/fabric-logger-helm-v2.0.2.tgz
+                 https://github.com/splunk/fabric-logger/releases/download/v3.0.0/fabric-logger-helm-v3.0.0.tgz
 
 ### Kubernetes: Deleting Helm Chart
 
@@ -177,7 +174,6 @@ You will also need to update the `network.yaml` with appropriate values for you 
 | FABRIC_CLIENT_CERTFILE          | client-certfile          | The client signed certificate used in mutual TLS.                                          | None               |
 | FABRIC_MSP                      | msp                      | The name of the MSP that the logging user is enrolled in.                                  | None (Required)    |
 | FABRIC_LOGGER_USERNAME          | user                     | The username the that the `FABRIC_KEYFILE` is enrolled under.                              | None (Required)    |
-| FABRIC_PEER                     | peer                     | The hostname of the peer to connect to.                                                    | None (Required)    |
 | NETWORK_CONFIG                  | network                  | A network configuration object, an example can be found [here](https://hyperledger.github.io/fabric-sdk-node/release-1.4/tutorial-network-config.html)                                                                                                                                                     | None (Required)    |
 | LOGGING_LOCATION                |                          | The logging location, valid values are `splunk` or `stdout`.                               | `splunk`           |
 | SPLUNK_HEC_TOKEN                | hec-token                | If using `splunk` as the logging location, the HEC token value.                            | None               |
@@ -188,3 +184,5 @@ You will also need to update the `network.yaml` with appropriate values for you 
 | SPLUNK_INDEX                    | hec-events-index         | Splunk index to log to.                                                                    | `hyperledger_logs` |
 | CHECKPOINTS_FILE                |                          | A file used to hold checkpoints for each channel watched. If running in docker, be sure to mount a volume so that the file is not lost between restarts.                                                                                                                                                 | `.checkpoints`     |
 | FABRIC_LOGGER_CONFIG            | config-file              | Location of a yaml file for fabric logger configuration, see example file fabriclogger.yaml.example | fabriclogger.yaml |
+| FABRIC_DISCOVERY                | discovery                | Indicates if peers and orderers should be discovered using the discovery service.  If set to false only the network.yaml will be used | false |
+| FABRIC_DISCOVERY_AS_LOCALHOST   | discovery-as-localhost   | Convert discovered host addresses to be localhost. Will be needed when running a docker composed fabric network on the local system; otherwise should be disabled. | false |

--- a/README.md
+++ b/README.md
@@ -77,15 +77,6 @@ Running the Fabric Logger in Docker is recommended. A sample docker-compose entr
 
 We also include a helm chart for Kubernetes deployments. First set your `values.yaml` file. Here is an example configuration (although this will be specific to your environment):
 
-    peers:
-        peer0:
-            mspName: PeerMSP
-            peerName: peer0
-            username: admin
-            peerAddress: peer0.example.com
-            channels:
-                - mychannel
-
     splunk:
         hec:
             token: 12345678-ABCD-EFGH-IJKL-123456789012
@@ -97,21 +88,27 @@ We also include a helm chart for Kubernetes deployments. First set your `values.
         peer:
             cert: hlf-peer--peer0-cert
             key: hlf-peer--peer0-key
-    channels:
-        - channel1
-        - channel2
-    ccevents:
-        - channelName: channel1
-          chaincodeId: myChaincodeId
-        - channelName: channel1
-          chaincodeId: myChaincodeId
+
+    fabric:
+        msp: PeerMSP
+        orgDomain: example.com
+        blockType: full
+        user: Admin
+        channels:
+            - channel1
+            - channel2
+        ccevents:
+            - channelName: channel1
+              chaincodeId: myChaincodeId
+            - channelName: channel1
+              chaincodeId: myChaincodeId
 
 ### Kubernetes: Autogenerating Secrets
 
 Alternatively, if you are using `cryptogen` to generate identities, the helm chart can auto-populate secrets for you. You will need to download the helm file and untar it locally so you can copy your `crypto-config` into the director.
 
-    wget https://github.com/splunk/fabric-logger/releases/download/2.0.2/fabric-logger-helm-v2.0.2.tgz
-    tar -xf fabric-logger-helm-v2.0.2.tgz
+    wget https://github.com/splunk/fabric-logger/releases/download/3.0.0/fabric-logger-helm-v3.0.0.tgz
+    tar -xf fabric-logger-helm-v3.0.0.tgz
     cp -R crypto-config fabric-logger/crypto-config
 
 Set the secrets section of `values.yaml` to:
@@ -122,8 +119,8 @@ Set the secrets section of `values.yaml` to:
 
 You can now deploy using:
 
-    helm install -n fabric-logger-${PEER_NAME}-${NS} --namespace ${NS} \
-                 -f values.yaml ./fabric-logger
+    helm install -n fabric-logger-${NS} --namespace ${NS} \
+                 -f values.yaml -f network.yaml ./fabric-logger
 
 ### Kubernetes: Manually Populating Secrets
 
@@ -138,10 +135,10 @@ Make sure that the peer credentials are stored in the appropriately named secret
     KEY=$(find ${ADMIN_MSP_DIR}/keystore/*_sk -type f)
     kubectl create secret generic -n ${NS} hlf-peer--peer0-key --from-file=key.pem=$KEY
 
-A `network.yaml` will automatically be generated using the secrets and channel details set above. You can deploy via helm:
+A `network.yaml` configmap will automatically be generated using the secrets and channel details set above. You can deploy via helm:
 
     helm install -n fabric-logger-${PEER_NAME}-${NS} --namespace ${NS} \
-                 -f values.yaml \
+                 -f values.yaml -f network.yaml \
                  https://github.com/splunk/fabric-logger/releases/download/v3.0.0/fabric-logger-helm-v3.0.0.tgz
 
 ### Kubernetes: Deleting Helm Chart

--- a/defaults.fabriclogger.yaml
+++ b/defaults.fabriclogger.yaml
@@ -2,12 +2,14 @@ fabric:
     network: network.yaml
     user: fabric-logger
     blockType: 'full'
+    discovery: false
+    asLocalhost: false
 output:
     type: hec
     sourceTypePrefix: 'fabric_logger'
     sourcetypes:
         block: 'fabric_logger:block'
-        endorserTransaction: 'fabric_logger:endorser_transaction'
+        endorser_transaction: 'fabric_logger:endorser_transaction'
         config: 'fabric_logger:config'
         ccevent: 'fabric_logger:ccevent'
 checkpoint:

--- a/defaults.fabriclogger.yaml
+++ b/defaults.fabriclogger.yaml
@@ -1,6 +1,7 @@
 fabric:
     network: network.yaml
     user: fabric-logger
+    blockType: 'full'
 output:
     type: hec
     sourceTypePrefix: 'fabric_logger'

--- a/examples/minifab/docker-compose.yml
+++ b/examples/minifab/docker-compose.yml
@@ -29,7 +29,6 @@ services:
             - FABRIC_CLIENT_CERTFILE=/crypto-config/peerOrganizations/org0.example.com/peers/peer1.org0.example.com/tls/server.crt
             - FABRIC_MSP=org0-example-com
             - FABRIC_LOGGER_USERNAME=Admin
-            - FABRIC_PEER=peer1.org0.example.com
             - NETWORK_CONFIG=/tmp/network-config.yml
             - SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000000
             - SPLUNK_HEC_URL=https://splunk.example.com:8088

--- a/examples/minifab/fabriclogger.yml
+++ b/examples/minifab/fabriclogger.yml
@@ -1,4 +1,3 @@
 fabric:
-    peer: peer0.org1.example.com
     channels:
         - mychannel

--- a/fabriclogger.yaml.example
+++ b/fabriclogger.yaml.example
@@ -1,8 +1,7 @@
 fabric:
-  peer: peer0.example.com
   blockType: full
   channels:
     - myChannel
-      ccevents:
-        chaincodeId: myChaincodeId
-    - mySecondChannel
+  ccevents:
+    channelName: myChannel
+    chaincodeId: myChaincodeId

--- a/fabriclogger.yaml.example
+++ b/fabriclogger.yaml.example
@@ -3,11 +3,6 @@ fabric:
   blockType: full
   channels:
     - myChannel
+      ccevents:
+        chaincodeId: myChaincodeId
     - mySecondChannel
-  ccevents:
-    - channelName: myChannel
-      filter: myEvent
-      chaincodeId: myChaincodeId
-    - channelName: myChannel
-      filter: myOtherEvent
-      chaincodeId: myChaincodeId

--- a/fabriclogger.yaml.example
+++ b/fabriclogger.yaml.example
@@ -1,5 +1,6 @@
 fabric:
   peer: peer0.example.com
+  blockType: full
   channels:
     - myChannel
     - mySecondChannel

--- a/helm-chart/fabric-logger/Chart.yaml
+++ b/helm-chart/fabric-logger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v2.0.2"
+appVersion: "v3.0.0"
 description: A Helm chart for Splunk Connect for Hyperledger Fabric
 name: fabric-logger
-version: v2.0.2
+version: v3.0.0
 keywords:
   - blockchain
   - hyperledger

--- a/helm-chart/fabric-logger/templates/NOTES.txt
+++ b/helm-chart/fabric-logger/templates/NOTES.txt
@@ -12,7 +12,6 @@
 Listen to your data.
 
 SSplunk Connect for Hyperledger Fabric is spinning up in your cluster.
-It is configured to connect to the peer: {{ .Values.peer.peerName }}
 
 If you get stuck, we're here to help.
 Look for answers here: http://www.github.com/splunk/fabric-logger

--- a/helm-chart/fabric-logger/templates/configmap.yaml
+++ b/helm-chart/fabric-logger/templates/configmap.yaml
@@ -26,17 +26,22 @@ data:
           path: /var/hyperledger/msp/signcerts/cert.pem
     
     peers:
-      {{ .Values.peer.peerName }}:
-        url: {{ .Values.peer.peerScheme }}://{{ .Values.peer.peerAddress }}:{{ .Values.peer.peerPort }}
+      {{- range .Values.peers }}
+      {{ $.peerName }}:
+        url: {{ $.peerScheme }}://{{ $.peerAddress }}:{{ $.peerPort }}
         grpcOptions:
-          ssl-target-name-override: {{ .Values.peer.peerAddress }}
+          ssl-target-name-override: {{ $.peerAddress }}
           grpc.keepalive_time_ms: 600000
-        {{- if eq .Values.peer.peerScheme "grpcs"}}
+        {{- if eq $.peerScheme "grpcs"}}
         tlsCACerts:
           path: /var/hyperledger/msp/tlscacert/tlscacert.pem
         {{- end }}
+      {{- end }}
   fabriclogger.yaml: |-
     fabric:
+      blockType: {{ .Values.fabric.blockType }}
+      discovery: {{ .Values.fabric.discovery }}
+      asLocalhost: {{ .Values.fabric.asLocalhost }}
       channels:
         {{- range .Values.channels }}
         - {{ . }}
@@ -44,6 +49,5 @@ data:
       ccevents:
         {{- range .Values.ccevents }}
         - channelName: {{ .channelName }}
-          filter: {{ .filter }}
           chaincodeId: {{ .chaincodeId }}
         {{- end }}

--- a/helm-chart/fabric-logger/templates/configmap.yaml
+++ b/helm-chart/fabric-logger/templates/configmap.yaml
@@ -1,53 +1,54 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "fabric-logger.name" . }}-{{ .Values.peer.peerName }}-network-config
+  name: {{ include "fabric-logger.name" . }}-network-config
 data:
   network.yaml: |-
-    name: Fabric
+    name: "Network"
     version: "1.0"
-    
+    client:
+      {{ toYaml .Values.client }}
     channels:
-      {{- range .Values.peer.channels }}
-      {{ . }}:
+      {{- range $key, $value:=.Values.channels }}
+      {{ $key }}:
         peers:
-          {{ $.Values.peer.peerName }}:
-            eventSource: true
-      {{- end }}
-    
-    organizations:
-      org:
-        mspid: {{ .Values.peer.mspName }}
-        peers:
-        - {{ .Values.peer.peerName }}
-        adminPrivateKey:
-          path: /var/hyperledger/msp/keystore/key.pem
-        signedCert:
-          path: /var/hyperledger/msp/signcerts/cert.pem
-    
-    peers:
-      {{- range .Values.peers }}
-      {{ $.peerName }}:
-        url: {{ $.peerScheme }}://{{ $.peerAddress }}:{{ $.peerPort }}
-        grpcOptions:
-          ssl-target-name-override: {{ $.peerAddress }}
-          grpc.keepalive_time_ms: 600000
-        {{- if eq $.peerScheme "grpcs"}}
-        tlsCACerts:
-          path: /var/hyperledger/msp/tlscacert/tlscacert.pem
+        {{- range .peers }}
+          {{ . }}:  
         {{- end }}
       {{- end }}
+    organizations:
+      {{- range $key, $value:= .Values.organizations }}
+      {{ $key }}:
+        mspid: {{ .mspid }}
+        peers:
+          {{- range .peers }}
+          - {{ . }}
+          {{- end }}
+      {{- end }}
+    peers:
+      {{- range $key, $value:= .Values.peers }}
+      {{ $key }}:
+        url: {{ .url }}
+        grpcOption:
+        {{- range $key,$value:= .grpcOptions }}
+          {{ $key }}: {{ toYaml $value }}
+        {{- end }}
+        tlsCACerts:
+          path: /var/hyperledger/msp/tlscacert/tlscacert.pem
+      {{- end }}
+
   fabriclogger.yaml: |-
     fabric:
       blockType: {{ .Values.fabric.blockType }}
       discovery: {{ .Values.fabric.discovery }}
       asLocalhost: {{ .Values.fabric.asLocalhost }}
+      user: {{ .Values.fabric.user }}
       channels:
-        {{- range .Values.channels }}
+        {{- range .Values.fabric.channels }}
         - {{ . }}
         {{- end }}
       ccevents:
-        {{- range .Values.ccevents }}
+        {{- range .Values.fabric.ccevents }}
         - channelName: {{ .channelName }}
           chaincodeId: {{ .chaincodeId }}
         {{- end }}

--- a/helm-chart/fabric-logger/templates/deployment.yaml
+++ b/helm-chart/fabric-logger/templates/deployment.yaml
@@ -65,8 +65,6 @@ spec:
           {{- end }}
           - name: FABRIC_MSP
             value: {{ .Values.peer.mspName | quote }}
-          - name: FABRIC_PEER
-            value: {{ .Values.peer.peerName | quote }}
           - name: FABRIC_LOGGER_USERNAME
             value: {{ .Values.peer.username | quote }}
           - name: SPLUNK_HEC_TOKEN

--- a/helm-chart/fabric-logger/templates/deployment.yaml
+++ b/helm-chart/fabric-logger/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fabric-logger.name" . }}-{{ .Values.peer.peerName }}
+  name: {{ include "fabric-logger.name" . }}
   labels:
     app.kubernetes.io/name: {{ include "fabric-logger.name" . }}
     helm.sh/chart: {{ include "fabric-logger.chart" . }}
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["fabriclogger"]
           args: ["-c", "network/fabriclogger.yaml"]
@@ -64,9 +64,9 @@ spec:
             value: "/var/hyperledger/tls/keystore/clientKey.pem"
           {{- end }}
           - name: FABRIC_MSP
-            value: {{ .Values.peer.mspName | quote }}
+            value: {{ .Values.fabric.msp | quote }}
           - name: FABRIC_LOGGER_USERNAME
-            value: {{ .Values.peer.username | quote }}
+            value: {{ .Values.fabric.user | quote }}
           - name: SPLUNK_HEC_TOKEN
             value: {{ .Values.splunk.hec.token | quote }}
           - name: SPLUNK_HEC_URL
@@ -86,7 +86,7 @@ spec:
       volumes:
       - name: network 
         configMap:
-          name: {{ include "fabric-logger.name" . }}-{{ .Values.peer.peerName }}-network-config
+          name: {{ include "fabric-logger.name" . }}-network-config
 
       {{- if .Values.secrets.peer.cert }}
       - name: id-cert
@@ -100,7 +100,7 @@ spec:
       {{- else if .Values.secrets.peer.create }}
       - name: id-cert
         secret:
-          secretName: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+          secretName: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
           items:
             - key: cert.pem
               path: cert.pem
@@ -118,7 +118,7 @@ spec:
       {{- else if .Values.secrets.peer.create }}
       - name: id-key
         secret:
-          secretName: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+          secretName: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
           items:
             - key: key.pem
               path: key.pem
@@ -136,7 +136,7 @@ spec:
       {{- else if .Values.secrets.peer.create }}
       - name: tls-cert
         secret:
-          secretName: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+          secretName: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
           items:
             - key: tlscacert.pem
               path: tlscacert.pem
@@ -154,7 +154,7 @@ spec:
       {{- else if .Values.secrets.peer.create }}
       - name: id-clientkey
         secret:
-          secretName: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+          secretName: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
           items:
             - key: clientKey.pem
               path: clientKey.pem
@@ -172,7 +172,7 @@ spec:
       {{- else if .Values.secrets.peer.create }}
       - name: id-clientcert
         secret:
-          secretName: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+          secretName: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
           items:
             - key: clientCert.pem
               path: clientCert.pem

--- a/helm-chart/fabric-logger/templates/secret.yaml
+++ b/helm-chart/fabric-logger/templates/secret.yaml
@@ -3,21 +3,20 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: fabric-logger--{{ .Values.peer.orgDomain | lower }}--{{ .Values.peer.peerName  | lower }}-msp
+  name: fabric-logger--{{ .Values.fabric.orgDomain | lower }}-msp
   labels:
-    orgDomain: {{ .Values.peer.orgDomain }}
-    peerName: {{ .Values.peer.peerName }}
+    orgDomain: {{ .Values.fabric.orgDomain }}
 data:
   cert.pem: |-
-      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/signcerts/%s@%s-cert.pem" .Values.peer.orgDomain .Values.peer.username .Values.peer.orgDomain .Values.peer.username .Values.peer.orgDomain ) | b64enc }}
+      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/signcerts/%s@%s-cert.pem" .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain ) | b64enc }}
   tlscacert.pem: |- 
-      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/tlscacerts/tlsca.%s-cert.pem" .Values.peer.orgDomain .Values.peer.username .Values.peer.orgDomain .Values.peer.orgDomain ) | b64enc }}
-  {{- range $path, $bytes := $.Files.Glob (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/keystore/*" .Values.peer.orgDomain .Values.peer.username .Values.peer.orgDomain ) }}
+      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/tlscacerts/tlsca.%s-cert.pem" .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain .Values.fabric.orgDomain ) | b64enc }}
+  {{- range $path, $bytes := $.Files.Glob (printf "crypto-config/peerOrganizations/%s/users/%s@%s/msp/keystore/*" .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain ) }}
   key.pem: |-
       {{ $.Files.Get $path | b64enc }}
   {{- end }}
   clientCert.pem: |-
-      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/peers/%s.%s/tls/server.crt" .Values.peer.orgDomain .Values.peer.peerName .Values.peer.orgDomain ) | b64enc }}
+      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/tls/client.crt" .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain ) | b64enc }}
   clientKey.pem: |-
-      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/peers/%s.%s/tls/server.key" .Values.peer.orgDomain .Values.peer.peerName .Values.peer.orgDomain ) | b64enc }}
+      {{ $.Files.Get (printf "crypto-config/peerOrganizations/%s/users/%s@%s/tls/client.key" .Values.fabric.orgDomain .Values.fabric.user .Values.fabric.orgDomain ) | b64enc }}
 {{- end}}

--- a/helm-chart/fabric-logger/values.yaml
+++ b/helm-chart/fabric-logger/values.yaml
@@ -33,26 +33,6 @@ secrets:
     # clientCertItem: clientCert.pem
     # clientKey: hlf--peer-clientkey
     # clientKeyItem: clientKey.pem
-peers:
-  peer0:
-    mspName: PeerMSP
-    peerName: peer
-    username: Admin   # If secrets.peer.create = true, this is the user that will be used in the crytpogen directory.
-    orgDomain: example.com
-    peerScheme: grpc  # grpc or grpcs
-    peerAddress: peer.default.svc
-    peerPort: 7051
-
-channels:
-  # A list of channel names that this peer connects to:
-  - channel1
-  - channel2
-ccevents:
-  # A list of chaincode events to listen for:
-  - channelName: myChannel
-    chaincodeId: myChaincodeId
-  - channelName: myChannel
-    chaincodeId: myChaincodeId
 
 loggingLocation: splunk
 splunk:

--- a/helm-chart/fabric-logger/values.yaml
+++ b/helm-chart/fabric-logger/values.yaml
@@ -6,11 +6,16 @@ replicaCount: 1
 
 image:
   repository: splunkdlt/fabric-logger
-  tag: release-2.0.2
+  tag: release-3.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
 fullnameOverride: ""
+
+fabric:
+  blockType: full
+  discovery: false
+  asLocalhost: false
 
 secrets:
   peer:
@@ -28,15 +33,15 @@ secrets:
     # clientCertItem: clientCert.pem
     # clientKey: hlf--peer-clientkey
     # clientKeyItem: clientKey.pem
-
-peer:
-  mspName: PeerMSP
-  peerName: peer
-  username: Admin   # If secrets.peer.create = true, this is the user that will be used in the crytpogen directory.
-  orgDomain: example.com
-  peerScheme: grpc  # grpc or grpcs
-  peerAddress: peer.default.svc
-  peerPort: 7051
+peers:
+  peer0:
+    mspName: PeerMSP
+    peerName: peer
+    username: Admin   # If secrets.peer.create = true, this is the user that will be used in the crytpogen directory.
+    orgDomain: example.com
+    peerScheme: grpc  # grpc or grpcs
+    peerAddress: peer.default.svc
+    peerPort: 7051
 
 channels:
   # A list of channel names that this peer connects to:
@@ -45,10 +50,8 @@ channels:
 ccevents:
   # A list of chaincode events to listen for:
   - channelName: myChannel
-    filter: myEvent
     chaincodeId: myChaincodeId
   - channelName: myChannel
-    filter: myOtherEvent
     chaincodeId: myChaincodeId
 
 loggingLocation: splunk

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest --config jest.config.json",
     "generate": "yarn generate:cleanup && mkdir -p generated && yarn generate:pbjs && yarn generate:pbts",
     "generate:cleanup": "rm -rf generated",
-    "generate:pbjs": "pbjs -t static-module -w commonjs -o generated/protos.js node_modules/fabric-client/lib/protos/common/policies.proto node_modules/fabric-client/lib/protos/peer/chaincode.proto node_modules/fabric-client/lib/protos/peer/proposal.proto",
+    "generate:pbjs": "pbjs -t static-module -w commonjs -o generated/protos.js node_modules/fabric-protos/protos/peer/collection.proto node_modules/fabric-protos/protos/common/collection.proto node_modules/fabric-protos/protos/gossip/message.proto node_modules/fabric-protos/protos/discovery/protocol.proto node_modules/fabric-protos/protos/msp/msp_config.proto node_modules/fabric-protos/protos/msp/msp_principal.proto node_modules/fabric-protos/protos/common/policies.proto node_modules/fabric-protos/protos/peer/chaincode.proto node_modules/fabric-protos/protos/peer/proposal.proto",
     "generate:pbts": "pbts -o generated/protos.d.ts generated/protos.js"
   },
   "files": [
@@ -44,7 +44,7 @@
     "@types/lodash": "^4.14.138",
     "debug": "^4.1.1",
     "express": "^4.17.1",
-    "fabric-client": "^1.4.7",
+    "fabric-network": "^2.2.2",
     "fs-extra": "^9.0.1",
     "ini": "^1.3.5",
     "js-yaml": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric-logger",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Hyperledger Fabric Splunk integration",
   "author": "splunk <blockchain@splunk.com>",
   "main": "lib/index.js",

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -94,11 +94,7 @@ export class Checkpoint implements ManagedResource {
         this.scheduleWriteCheckpoints();
     }
 
-    public storeChaincodeEventCheckpoint(
-        channelName: string,
-        chaincodeId: string,
-        block: number
-    ) {
+    public storeChaincodeEventCheckpoint(channelName: string, chaincodeId: string, block: number) {
         if (this.globalCheckpoints == null) {
             throw new Error('Checkpoints not loaded');
         }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -41,7 +41,7 @@ export class Checkpoint implements ManagedResource {
             debug('Loaded checkpoints: %o', this.globalCheckpoints);
         } else {
             info('Checkpoints file does not exist, starting with empty checkpoints dictionary');
-            this.globalCheckpoints = { };
+            this.globalCheckpoints = {};
         }
         return this.globalCheckpoints;
     }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -56,7 +56,7 @@ export class Checkpoint implements ManagedResource {
         }
     }
 
-    public scheduleWriteCheckpoints() {
+    public scheduleWriteCheckpoints(): void {
         this.latestWritePromise = this.latestWritePromise.then(() =>
             this.writeCheckpoints().catch((e) => {
                 error('Failed to write checkpoint file:', e);

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -42,7 +42,7 @@ export class Checkpoint implements ManagedResource {
         } else {
             info('Checkpoints file does not exist, starting with empty checkpoints dictionary');
             this.globalCheckpoints = {
-                ccevents: {}
+                ccevents: {},
             };
         }
         return this.globalCheckpoints;

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -41,7 +41,9 @@ export class Checkpoint implements ManagedResource {
             debug('Loaded checkpoints: %o', this.globalCheckpoints);
         } else {
             info('Checkpoints file does not exist, starting with empty checkpoints dictionary');
-            this.globalCheckpoints = {};
+            this.globalCheckpoints = {
+                ccevents: {}
+            };
         }
         return this.globalCheckpoints;
     }

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -8,7 +8,6 @@ const { debug, info, error } = createModuleDebug('checkpoint');
 export type Checkpoints = { [key: string]: any };
 export type CCEvent = {
     channelName: string;
-    filter: string;
     chaincodeId: string;
     block: number;
 };
@@ -96,16 +95,14 @@ export class Checkpoint implements ManagedResource {
     }
 
     public storeChaincodeEventCheckpoint(
-        name: string,
         channelName: string,
-        filter: string,
         chaincodeId: string,
         block: number
     ) {
         if (this.globalCheckpoints == null) {
             throw new Error('Checkpoints not loaded');
         }
-        this.globalCheckpoints.ccevents[name] = { channelName, filter, chaincodeId, block };
+        this.globalCheckpoints.ccevents[channelName] = { chaincodeId, block };
         this.scheduleWriteCheckpoints();
     }
 

--- a/src/cliflags.ts
+++ b/src/cliflags.ts
@@ -83,7 +83,8 @@ export const CLI_FLAGS = {
     }),
     'block-type': flags.string({
         env: 'BLOCK_TYPE',
-        description: 'Type of block to subscribe to full or additionally include private data.  NOTE: private is not available and should not be used prior to fabric 2.X',
+        description:
+            'Type of block to subscribe to full or additionally include private data.  NOTE: private is not available and should not be used prior to fabric 2.X',
         options: ['full', 'private'],
-    })
+    }),
 };

--- a/src/cliflags.ts
+++ b/src/cliflags.ts
@@ -38,10 +38,6 @@ export const CLI_FLAGS = {
         env: 'NETWORK_CONFIG',
         description: 'Network configuration file',
     }),
-    peer: flags.string({
-        env: 'FABRIC_PEER',
-        description: 'Hostname of peer to connect to',
-    }),
     msp: flags.string({
         env: 'FABRIC_MSP',
         description: 'The name of the MSP that the user is enrolled in',
@@ -86,5 +82,15 @@ export const CLI_FLAGS = {
         description:
             'Type of block to subscribe to full or additionally include private data.  NOTE: private is not available and should not be used prior to fabric 2.X',
         options: ['full', 'private'],
+    }),
+    discovery: flags.boolean({
+        env: 'FABRIC_DISCOVERY',
+        description:
+            'Indicates if peers and orderers should be discovered using the discovery service.  If set to false only the network.yaml will be used',
+    }),
+    'discovery-as-localhost': flags.boolean({
+        env: 'FABRIC_DISCOVERY_AS_LOCALHOST',
+        description:
+            'Convert discovered host addresses to be localhost. Will be needed when running a docker composed fabric network on the local system; otherwise should be disabled.',
     }),
 };

--- a/src/cliflags.ts
+++ b/src/cliflags.ts
@@ -81,4 +81,9 @@ export const CLI_FLAGS = {
         env: 'SPLUNK_PORT',
         description: 'DEPRECATED Port that splunk HEC is listening on to send',
     }),
+    'block-type': flags.string({
+        env: 'BLOCK_TYPE',
+        description: 'Type of block to subscribe to full or additionally include private data.  NOTE: private is not available and should not be used prior to fabric 2.X',
+        options: ['full', 'private'],
+    })
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -429,14 +429,15 @@ export async function loadFabricloggerConfig(flags: CliFlags, dryRun: boolean = 
         }
     };
 
-    const parseBlockType = (value: string | undefined): BlockType => {
+    const parseBlockType = (value: string | undefined): BlockType | undefined => {
         switch (value) {
+            case 'filtered':
+                throw new ConfigError('Config error BlockType filtered is not a supported option');
             case 'full':
             case 'private':
-            case 'filtered':
                 return value;
             default:
-                return 'full';
+                return undefined;
         }
     };
 
@@ -455,7 +456,7 @@ export async function loadFabricloggerConfig(flags: CliFlags, dryRun: boolean = 
             clientCertFile: flags['client-cert'] ?? defaults.fabric?.clientCertFile,
             channels: defaults.fabric?.channels ?? [],
             ccevents: parseCCEvents(defaults.fabric?.ccevents),
-            blockType: parseBlockType(flags['block-type']),
+            blockType: parseBlockType(flags['block-type']) ?? defaults.fabric?.blockType,
             discovery: flags['discovery'] ?? defaults.fabric?.discovery,
             asLocalHost: flags['discovery-as-localhost'] ?? defaults.fabric?.asLocalHost,
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,8 @@ export interface FabricConfigSchema {
     channels: string[];
     /** Chaincode events to listen to*/
     ccevents: CCEvent[];
+    /** Block Type full or private */
+    blockType: 'filtered' | 'full' | 'private';
 }
 
 export interface HecClientsConfigSchema {
@@ -322,11 +324,10 @@ const parseCCEvents = (value: DeepPartial<CCEvent>[] | undefined): CCEvent[] => 
     const ccEvents = [];
     if (value) {
         for (const ccEvent of value) {
-            if (ccEvent['channelName'] && ccEvent['chaincodeId'] && ccEvent['filter']) {
+            if (ccEvent['channelName'] && ccEvent['chaincodeId']) {
                 ccEvents.push({
                     channelName: ccEvent['channelName'],
                     chaincodeId: ccEvent['chaincodeId'],
-                    filter: ccEvent['filter'],
                     block: ccEvent['block'] || 0,
                 });
             }
@@ -441,6 +442,7 @@ export async function loadFabricloggerConfig(flags: CliFlags, dryRun: boolean = 
             clientCertFile: flags['client-cert'] ?? defaults.fabric?.clientCertFile,
             channels: defaults.fabric?.channels ?? [],
             ccevents: parseCCEvents(defaults.fabric?.ccevents),
+            blockType: required('block-type', defaults.fabric?.blockType),
         },
         hec: {
             default: {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,25 +1,33 @@
 const isPlainObject = (obj: any): obj is Object =>
     typeof obj === 'object' && Object.prototype.toString.call(obj) === '[object Object]';
 
-export function convertBuffersToHex(obj: any, path: string[] = []): any {
+export function convertBuffers(obj: any, path: string[] = []): any {
     if (obj == null) {
         return obj;
     }
     if (obj instanceof Buffer) {
         // debug('Converting buffer value to hex at path %o', path.join('.'));
-        return { hex: obj.toString('hex') };
+        if (isLikelyText(obj)){
+            return { string: obj.toString('utf-8') };
+        }else{
+            return { hex: obj.toString('hex') };
+        }
     }
     if (Array.isArray(obj)) {
-        return obj.map((v, i) => convertBuffersToHex(v, [...path, String(i)]));
+        return obj.map((v, i) => convertBuffers(v, [...path, String(i)]));
     } else if (isPlainObject(obj)) {
         const result: { [k: string]: any } = {};
         Object.keys(obj).forEach((k) => {
             const v = obj[k];
             if (v instanceof Buffer) {
                 // debug('Converting buffer property to hex at path %o.%o', path.join('.'), k);
-                result[`${k}_hex`] = v.toString('hex');
+                if (isLikelyText(v)){
+                    result[`${k}_string`] = v.toString('utf-8');
+                }else{
+                    result[`${k}_hex`] = v.toString('hex');
+                }
             } else {
-                result[k] = convertBuffersToHex(v, [...path, k]);
+                result[k] = convertBuffers(v, [...path, k]);
             }
         });
         return result;

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,7 +1,7 @@
 const isPlainObject = (obj: any): obj is Object =>
     typeof obj === 'object' && Object.prototype.toString.call(obj) === '[object Object]';
 
-export function convertBuffers(obj: any, path: string[] = []): any {
+export function convertBuffers(obj: Buffer | Object | any | undefined, path: string[] = []): any {
     if (obj == null) {
         return obj;
     }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -7,9 +7,9 @@ export function convertBuffers(obj: any, path: string[] = []): any {
     }
     if (obj instanceof Buffer) {
         // debug('Converting buffer value to hex at path %o', path.join('.'));
-        if (isLikelyText(obj)){
+        if (isLikelyText(obj)) {
             return { string: obj.toString('utf-8') };
-        }else{
+        } else {
             return { hex: obj.toString('hex') };
         }
     }
@@ -21,9 +21,9 @@ export function convertBuffers(obj: any, path: string[] = []): any {
             const v = obj[k];
             if (v instanceof Buffer) {
                 // debug('Converting buffer property to hex at path %o.%o', path.join('.'), k);
-                if (isLikelyText(v)){
+                if (isLikelyText(v)) {
                     result[`${k}_string`] = v.toString('utf-8');
-                }else{
+                } else {
                     result[`${k}_hex`] = v.toString('hex');
                 }
             } else {

--- a/src/fabric.ts
+++ b/src/fabric.ts
@@ -85,11 +85,13 @@ export class FabricListener implements ManagedResource {
                     key: clientKey,
                 },
             };
-            return this.gateway.connect(connectionProfile, gatewayOptions);
+            await this.gateway.connect(connectionProfile, gatewayOptions);
+            info('Finished Connecting to gateway');
         }
     }
 
     public async listen(): Promise<void> {
+        info('Starting to listen on channels');
         for (const channel of this.checkpoint.getAllChannelsWithCheckpoints()) {
             info('Resuming listener for channel=%s', channel);
             const listener = await retry(() => this.registerListener(channel), {

--- a/src/fabric.ts
+++ b/src/fabric.ts
@@ -269,7 +269,10 @@ export class FabricListener implements ManagedResource {
         const network = await this.gateway.getNetwork(channelName);
         const latestCheckpoint = this.checkpoint.getChannelCheckpoint(channelName);
         info('Subscribing to block events on channel=%s from block number=%d', channelName, latestCheckpoint);
-        return network.addBlockListener(this.processBlock, { startBlock: latestCheckpoint, type: this.config.blockType });
+        return network.addBlockListener(this.processBlock, {
+            startBlock: latestCheckpoint,
+            type: this.config.blockType,
+        });
     }
 
     private processChaincodeEvent: ContractListener = async (event: ContractEvent) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ class Fabriclogger extends Command {
 
     private resources: ManagedResource[] = [];
 
-    async run() {
+    async run(): Promise<void> {
         const { flags } = this.parse(Fabriclogger);
         if (flags.debug) {
             debugModule.enable('fabriclogger:*');
@@ -46,7 +46,7 @@ class Fabriclogger extends Command {
         }
     }
 
-    async startFabriclogger(config: FabricloggerConfig) {
+    async startFabriclogger(config: FabricloggerConfig): Promise<void> {
         const checkpoint = new Checkpoint(config.checkpoint.filename);
         await checkpoint.loadCheckpoints();
         this.resources.push(checkpoint);

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -1,4 +1,3 @@
-
 import { ContractEvent, TransactionEvent } from 'fabric-network';
 import { BlockData } from 'fabric-common';
 
@@ -16,7 +15,7 @@ export interface EndorserTransactionMessage extends BlockData {
     block_number: number;
 }
 
-export interface ChaincodeEventMessage extends ContractEvent{
+export interface ChaincodeEventMessage extends ContractEvent {
     type: 'ccevent';
     block_number: number | undefined;
     channel: string | undefined;

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -1,6 +1,8 @@
-import { Block, BlockData, ChaincodeEvent } from 'fabric-client';
 
-export interface BlockMessage extends Block {
+import { ContractEvent, TransactionEvent } from 'fabric-network';
+import { BlockData } from 'fabric-common';
+
+export interface BlockMessage {
     type: 'block';
 }
 
@@ -14,17 +16,18 @@ export interface EndorserTransactionMessage extends BlockData {
     block_number: number;
 }
 
-export interface ChaincodeEventMessage {
+export interface ChaincodeEventMessage extends ContractEvent{
     type: 'ccevent';
     block_number: number | undefined;
     channel: string | undefined;
-    transaction_id: string | undefined;
-    transaction_status: string | undefined;
-    event: ChaincodeEvent;
     payload_message: string | undefined;
 }
 
 export interface UnKnownMessage extends BlockData {
     type: string;
     block_number: number | undefined;
+}
+
+export interface TransactionEventMessage extends TransactionEvent {
+    type: string;
 }

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -10,11 +10,6 @@ export interface ConfigMessage extends BlockData {
     block_number: number;
 }
 
-export interface EndorserTransactionMessage extends BlockData {
-    type: 'endorserTransaction';
-    block_number: number;
-}
-
 export interface ChaincodeEventMessage extends ContractEvent {
     type: 'ccevent';
     block_number: number | undefined;
@@ -29,4 +24,7 @@ export interface UnKnownMessage extends BlockData {
 
 export interface TransactionEventMessage extends TransactionEvent {
     type: string;
+    block_number: number;
+    channel: string;
+    channel_header: any;
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -5,7 +5,14 @@ import { convertBuffers } from './convert';
 import { HecClient } from '@splunkdlt/hec-client';
 import { ManagedResource } from '@splunkdlt/managed-resource';
 import { FabricloggerConfig, HecOutputConfig } from './config';
-import { BlockMessage, ConfigMessage, EndorserTransactionMessage, ChaincodeEventMessage, TransactionEventMessage, UnKnownMessage } from './msgs';
+import {
+    BlockMessage,
+    ConfigMessage,
+    EndorserTransactionMessage,
+    ChaincodeEventMessage,
+    TransactionEventMessage,
+    UnKnownMessage,
+} from './msgs';
 
 export type OutputMessage =
     | BlockMessage

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,17 +1,18 @@
 import { createModuleDebug } from '@splunkdlt/debug-logging';
 import { pathExists, mkdir, writeFile } from 'fs-extra';
 import { join } from 'path';
-import { convertBuffersToHex } from './convert';
+import { convertBuffers } from './convert';
 import { HecClient } from '@splunkdlt/hec-client';
 import { ManagedResource } from '@splunkdlt/managed-resource';
 import { FabricloggerConfig, HecOutputConfig } from './config';
-import { BlockMessage, ConfigMessage, EndorserTransactionMessage, ChaincodeEventMessage, UnKnownMessage } from './msgs';
+import { BlockMessage, ConfigMessage, EndorserTransactionMessage, ChaincodeEventMessage, TransactionEventMessage, UnKnownMessage } from './msgs';
 
 export type OutputMessage =
     | BlockMessage
     | ConfigMessage
     | EndorserTransactionMessage
     | ChaincodeEventMessage
+    | TransactionEventMessage
     | UnKnownMessage;
 
 const { debug } = createModuleDebug('output');
@@ -26,7 +27,7 @@ export interface Output extends ManagedResource {
 export class HecOutput implements Output, ManagedResource {
     constructor(private eventsHec: HecClient, private metricsHec: HecClient, private config: HecOutputConfig) {}
     public logEvent(message: OutputMessage, timeField: Date | undefined, source: string): void {
-        const event = convertBuffersToHex(message);
+        const event = convertBuffers(message);
         switch (message.type) {
             case 'block':
             case 'endorserTransaction':

--- a/src/output.ts
+++ b/src/output.ts
@@ -5,19 +5,11 @@ import { convertBuffers } from './convert';
 import { HecClient } from '@splunkdlt/hec-client';
 import { ManagedResource } from '@splunkdlt/managed-resource';
 import { FabricloggerConfig, HecOutputConfig } from './config';
-import {
-    BlockMessage,
-    ConfigMessage,
-    EndorserTransactionMessage,
-    ChaincodeEventMessage,
-    TransactionEventMessage,
-    UnKnownMessage,
-} from './msgs';
+import { BlockMessage, ConfigMessage, ChaincodeEventMessage, TransactionEventMessage, UnKnownMessage } from './msgs';
 
 export type OutputMessage =
     | BlockMessage
     | ConfigMessage
-    | EndorserTransactionMessage
     | ChaincodeEventMessage
     | TransactionEventMessage
     | UnKnownMessage;
@@ -27,17 +19,17 @@ const filenameSafe = (name: string): string => name.replace(/[^\w]+/g, '_');
 const randSuffix = () => Math.floor(Math.random() * 0xfffffff).toString(36);
 
 export interface Output extends ManagedResource {
-    logEvent(event: OutputMessage, timeField: Date | undefined, source: string): void;
+    logEvent(event: OutputMessage, timeField: Date | undefined, source?: string): void;
     waitUntilAvailable?(maxTime: number): Promise<void>;
 }
 
 export class HecOutput implements Output, ManagedResource {
     constructor(private eventsHec: HecClient, private metricsHec: HecClient, private config: HecOutputConfig) {}
-    public logEvent(message: OutputMessage, timeField: Date | undefined, source: string): void {
+    public logEvent(message: OutputMessage, timeField: Date | undefined, source: string = 'fabriclogger'): void {
         const event = convertBuffers(message);
         switch (message.type) {
             case 'block':
-            case 'endorserTransaction':
+            case 'endorser_transaction':
             case 'config':
             case 'ccevent':
                 this.eventsHec.pushEvent({
@@ -75,7 +67,7 @@ export class HecOutput implements Output, ManagedResource {
         ]).then(() => Promise.resolve());
     }
 
-    public async shutdown() {
+    public async shutdown(): Promise<void> {
         return Promise.all([this.eventsHec.shutdown(), this.metricsHec.shutdown()]).then(() => {
             /* noop */
         });
@@ -99,25 +91,25 @@ export class FileOutput implements Output {
         return outputDir;
     }
 
-    public async logEvent(event: any) {
-        const meta = event.metadata || {};
+    public async logEvent(event: OutputMessage): Promise<void> {
+        const meta = {};
         const { sourcetype = 'unknown_sourcetype', time = Date.now() } = meta as any;
         const fileName = `event_${filenameSafe(sourcetype)}_${time}_${randSuffix()}.json`;
         debug(`Writing event to file`, fileName);
         await writeFile(join(this.outputDir, fileName), JSON.stringify(event, null, 2), { encoding: 'utf-8' });
     }
 
-    public async shutdown() {
+    public async shutdown(): Promise<void> {
         // noop
     }
 }
 
 export class ConsoleOutput implements Output {
-    logEvent(message: any): void {
+    logEvent(message: OutputMessage): void {
         // eslint-disable-next-line no-console
         console.log(JSON.stringify(message));
     }
-    public async shutdown() {
+    public async shutdown(): Promise<void> {
         // noop
     }
 }

--- a/src/protobuf.ts
+++ b/src/protobuf.ts
@@ -85,7 +85,7 @@ export function isSignaturePolicyEnvolope(buffer: Buffer): boolean {
     }
 }
 
-export function decodeSignaturePolicyEnvolope(buffer: Buffer) {
+export function decodeSignaturePolicyEnvolope(buffer: Buffer): any {
     const spe = common.SignaturePolicyEnvelope.decode(buffer);
     return {
         ...common.SignaturePolicyEnvelope.toObject(spe, DEFAULT_CONVERSION_OPTIONS),
@@ -93,12 +93,12 @@ export function decodeSignaturePolicyEnvolope(buffer: Buffer) {
     };
 }
 
-export function decodeChaincodeDeploymentSpec(buffer: Buffer) {
+export function decodeChaincodeDeploymentSpec(buffer: Buffer): any {
     const decoded = protos.ChaincodeDeploymentSpec.decode(buffer);
     return protos.ChaincodeDeploymentSpec.toObject(decoded, DEFAULT_CONVERSION_OPTIONS);
 }
 
-export function decodeChainCodeAction(buffer: Buffer) {
+export function decodeChainCodeAction(buffer: Buffer): any {
     const decoded = protos.ChaincodeAction.decode(buffer);
     return protos.ChaincodeAction.toObject(decoded, DEFAULT_CONVERSION_OPTIONS);
 }

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -1,9 +1,9 @@
-import { convertBuffersToHex, isLikelyText } from '../src/convert';
+import { convertBuffers, isLikelyText } from '../src/convert';
 
-describe('convertBuffersToHex', () => {
+describe('convertBuffers', () => {
     it('should return an object without buffers as-is', () => {
         expect(
-            convertBuffersToHex({
+            convertBuffers({
                 foo: 'bar',
                 some: 'thing',
                 anumber: 3,
@@ -21,32 +21,32 @@ describe('convertBuffersToHex', () => {
 
     it('should modify an object property containing a buffer', () => {
         expect(
-            convertBuffersToHex({
+            convertBuffers({
                 some: Buffer.from('foobar'),
             })
         ).toMatchInlineSnapshot(`
             Object {
-              "some_hex": "666f6f626172",
+              "some_string": "foobar",
             }
         `);
     });
 
     it('should convert an array of buffers to inline objects with the hex values', () => {
         expect(
-            convertBuffersToHex({
+            convertBuffers({
                 args: [Buffer.from('foobar'), Buffer.from('hello'), Buffer.from('world')],
             })
         ).toMatchInlineSnapshot(`
             Object {
               "args": Array [
                 Object {
-                  "hex": "666f6f626172",
+                  "string": "foobar",
                 },
                 Object {
-                  "hex": "68656c6c6f",
+                  "string": "hello",
                 },
                 Object {
-                  "hex": "776f726c64",
+                  "string": "world",
                 },
               ],
             }

--- a/test/protobuf.test.ts
+++ b/test/protobuf.test.ts
@@ -48,6 +48,7 @@ test('decodeChaincodeDeploymentSpec', () => {
                 },
               ],
               "decorations": Object {},
+              "isInit": false,
             },
             "timeout": 0,
             "type": "GOLANG",
@@ -56,7 +57,6 @@ test('decodeChaincodeDeploymentSpec', () => {
             "data": Array [],
             "type": "Buffer",
           },
-          "execEnv": "DOCKER",
         }
     `);
     expect(decodeChaincodeDeploymentSpec(buf2)).toMatchInlineSnapshot(`
@@ -80,6 +80,7 @@ test('decodeChaincodeDeploymentSpec', () => {
                 },
               ],
               "decorations": Object {},
+              "isInit": false,
             },
             "timeout": 0,
             "type": "GOLANG",
@@ -88,7 +89,6 @@ test('decodeChaincodeDeploymentSpec', () => {
             "data": Array [],
             "type": "Buffer",
           },
-          "execEnv": "DOCKER",
         }
     `);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,9 +696,9 @@
   integrity sha512-fYMgzN+9e28R81weVN49inn/u798ruU91En1ZnGvSZzCRc5jXx9B2EDhlRaWmcO1RIxFHL8AajRXzxDuJu93+A==
 
 "@types/json-schema@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
-  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
 "@types/lodash@^4.14.138":
   version "4.14.138"
@@ -791,15 +791,27 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.3.0.tgz#89518e5c5209a349bde161c3489b0ec187ae5d37"
-  integrity sha512-Ybx/wU75Tazz6nU2d7nN6ll0B98odoiYLXwcuwS5WSttGzK46t0n7TPRQ4ozwcTv82UY6TQoIvI+sJfTzqK9dQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz#7e061338a1383f59edc204c605899f93dc2e2c8f"
+  integrity sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "3.3.0"
+    "@typescript-eslint/experimental-utils" "3.10.1"
+    debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
+  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/typescript-estree" "3.10.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
 "@typescript-eslint/experimental-utils@3.3.0":
   version "3.3.0"
@@ -821,6 +833,25 @@
     "@typescript-eslint/typescript-estree" "3.3.0"
     eslint-visitor-keys "^1.1.0"
 
+"@typescript-eslint/types@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
+  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
+
+"@typescript-eslint/typescript-estree@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
+  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
+  dependencies:
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/visitor-keys" "3.10.1"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/typescript-estree@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.3.0.tgz#841ffed25c29b0049ebffb4c2071268a34558a2a"
@@ -833,6 +864,13 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
+  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 JSONStream@^1.2.1, JSONStream@^1.3.5:
   version "1.3.5"
@@ -2288,11 +2326,11 @@ eslint-plugin-prettier@^3.1.4:
     prettier-linter-helpers "^1.0.0"
 
 eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-scope@^5.1.0:
@@ -2311,9 +2349,9 @@ eslint-utils@^2.0.0:
     eslint-visitor-keys "^1.1.0"
 
 eslint-visitor-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^1.2.0:
   version "1.2.0"
@@ -2393,19 +2431,19 @@ esquery@^1.2.0:
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+esrecurse@^4.1.0, esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.1.0"
+    estraverse "^5.2.0"
 
 estraverse@^1.5.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
   integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -2414,6 +2452,11 @@ estraverse@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+
+estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -6811,7 +6854,12 @@ tslib@^1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,21 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@grpc/grpc-js@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.0.3.tgz#7fa2ba293ccc1e91b24074c2628c8c68336e18c4"
+  integrity sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==
+  dependencies:
+    semver "^6.2.0"
+
+"@grpc/proto-loader@0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.5.4.tgz#038a3820540f621eeb1b05d81fbedfb045e14de0"
+  integrity sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    protobufjs "^6.8.6"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -573,13 +588,10 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bytebuffer@^5.0.34", "@types/bytebuffer@^5.0.40":
-  version "5.0.40"
-  resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.40.tgz#d6faac40dcfb09cd856cdc4c01d3690ba536d3ee"
-  integrity sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==
-  dependencies:
-    "@types/long" "*"
-    "@types/node" "*"
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -693,15 +705,15 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
   integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
 
-"@types/long@*":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
-  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
-
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/mime@*":
   version "2.0.1"
@@ -723,6 +735,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.16.tgz#4d690c96cbb7b2728afea0e260d680501b3da5cf"
   integrity sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==
 
+"@types/node@^13.7.0":
+  version "13.13.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.16.tgz#66f2177047b61131eaac18c47eb25d6f1317070a"
+  integrity sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -732,6 +749,16 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/request@^2.48.4":
+  version "2.48.5"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
+  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
 
 "@types/serve-static@*":
   version "1.13.3"
@@ -745,6 +772,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tough-cookie@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/yargs-parser@*":
   version "13.0.0"
@@ -1072,14 +1104,6 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-ascli@~1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
-  integrity sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=
-  dependencies:
-    colour "~0.7.1"
-    optjs "~3.2.2"
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -1230,14 +1254,6 @@ binaryextensions@^2.1.2:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.2.0.tgz#e7c6ba82d4f5f5758c26078fe8eea28881233311"
   integrity sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw==
 
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
-  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
 bl@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
@@ -1247,7 +1263,7 @@ bl@^4.0.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bn.js@^4.11.3, bn.js@^4.4.0:
+bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
@@ -1333,7 +1349,7 @@ buffer-alloc-unsafe@^1.1.0:
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
   integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
 
-buffer-alloc@^1.1.0, buffer-alloc@^1.2.0:
+buffer-alloc@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
   integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
@@ -1358,13 +1374,6 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
-
-bytebuffer@~5:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
-  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
-  dependencies:
-    long "~3"
 
 bytes@3.1.0:
   version "3.1.0"
@@ -1651,14 +1660,14 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-cloudant-follow@~0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/cloudant-follow/-/cloudant-follow-0.17.0.tgz#842513a74e72c440e61dc2b6fd96eedbd9cef38a"
-  integrity sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==
+cloudant-follow@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/cloudant-follow/-/cloudant-follow-0.18.2.tgz#35dd7b29c5b9c58423d50691f848a990fbe2c88f"
+  integrity sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==
   dependencies:
     browser-request "~0.3.0"
-    debug "^3.0.0"
-    request "^2.83.0"
+    debug "^4.0.1"
+    request "^2.88.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1711,11 +1720,6 @@ colors@1.0.3, colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
-
-colour@~0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
-  integrity sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1978,7 +1982,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2194,13 +2198,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-
-end-of-stream@^1.0.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
 
 end-of-stream@^1.1.0:
   version "1.4.1"
@@ -2615,47 +2612,42 @@ eyes@0.1.x:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
-fabric-ca-client@latest:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/fabric-ca-client/-/fabric-ca-client-1.4.8.tgz#29415408d77b449e010ac38251b5eeddefaecdf3"
-  integrity sha512-1puz5zPU3I9SPZ4qtuQGuZW7QMUOSPuh1ncQakzdkk1J9Cewj8MdW67fhOUBPefkx5S2VSfJOfJ1iWTCjgf1XA==
+fabric-common@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fabric-common/-/fabric-common-2.2.2.tgz#ae818e58831e78b9eeee448aefed068b9b6f4016"
+  integrity sha512-OhIvZTTis7tSRzztCzss3+BM6R274ZIM1yFc6VZHqubW7SSAy5qkGyzROSHQEim/6HM5meGgEKS5aHKrLzkMtw==
   dependencies:
-    grpc "1.24.2"
-    jsrsasign "^7.2.2"
-    lodash.clone "4.5.0"
-    url "^0.11.0"
-    util "^0.10.3"
-    winston "^2.4.0"
-
-fabric-client@^1.4.7:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/fabric-client/-/fabric-client-1.4.8.tgz#0a71b6b8e00f5e993209b5768b5a65f71a5eefe2"
-  integrity sha512-EZUidCTa6+T1VArptUi9rPQ2ravWxZpldj4kAoDpLG8lW+cZzEzGeCDCp4kym4w/EtmOS4AMj9Ujfp/asvyF0A==
-  dependencies:
-    "@types/bytebuffer" "^5.0.34"
-    bn.js "^4.11.3"
     callsite "^1.0.0"
     elliptic "^6.5.2"
-    fabric-ca-client latest
-    fs-extra "^8.1.0"
-    grpc "1.24.2"
-    ignore-walk "^3.0.0"
+    fabric-protos "2.2.2"
     js-sha3 "^0.7.0"
-    js-yaml "^3.9.0"
-    jsrsasign "^7.2.2"
-    klaw "^2.0.0"
-    lodash.clone "4.5.0"
-    long "^4.0.0"
-    nano "^6.4.4"
+    jsrsasign "^8.0.20"
     nconf "^0.10.0"
     promise-settle "^0.3.0"
-    protobufjs "5.0.3"
     sjcl "1.0.7"
-    tar-stream "1.6.1"
-    url "^0.11.0"
     winston "^2.4.0"
+    yn "^3.1.0"
   optionalDependencies:
     pkcs11js "^1.0.6"
+
+fabric-network@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fabric-network/-/fabric-network-2.2.2.tgz#c1700aaac08032040c6ee8c7c09d639e6da109f7"
+  integrity sha512-zPZ+yrSyHSVzDVS7f9EEMxN9nKOQ7aDg0RX76efevH7PQ7atDogijMnw2EdYnHBcw/t/ATMlMqaIxkKJNBoPjg==
+  dependencies:
+    fabric-common "2.2.2"
+    fabric-protos "2.2.2"
+    long "^4.0.0"
+    nano "^8.2.2"
+
+fabric-protos@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fabric-protos/-/fabric-protos-2.2.2.tgz#572da200eec154835f0b353bc7c144033ff85f75"
+  integrity sha512-deXDIC4l9opKyu7zqZMXqiszxSOULKP66HmWZ435dgmQZyeo0rzFVO7dCwBZYdAVmz9pE4Ze8/qEU2GQ3suCJg==
+  dependencies:
+    "@grpc/grpc-js" "1.0.3"
+    "@grpc/proto-loader" "0.5.4"
+    protobufjs "^6.9.0"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -2809,6 +2801,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -2835,26 +2836,12 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
 fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -3029,7 +3016,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.4, glob@^7.1.6, glob@~7.1.4:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3146,7 +3133,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -3162,18 +3149,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-grpc@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
-  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
-  dependencies:
-    "@types/bytebuffer" "^5.0.40"
-    lodash.camelcase "^4.3.0"
-    lodash.clone "^4.5.0"
-    nan "^2.13.2"
-    node-pre-gyp "^0.14.0"
-    protobufjs "^5.0.3"
 
 handlebars@^4.1.2:
   version "4.5.3"
@@ -3191,7 +3166,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0, har-validator@~5.1.3:
+har-validator@~5.1.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -3404,7 +3379,7 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ignore-walk@^3.0.0, ignore-walk@^3.0.1:
+ignore-walk@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
   integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
@@ -4248,7 +4223,7 @@ js-sha3@^0.7.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4373,10 +4348,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsrsasign@^7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-7.2.2.tgz#ae5230cb5574451bb979a9cc697428c60f598d20"
-  integrity sha1-rlIwy1V0RRu5eanMaXQoxg9ZjSA=
+jsrsasign@^8.0.20:
+  version "8.0.24"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.24.tgz#fc26bac45494caac3dd8f69c1f95847c4bda6c83"
+  integrity sha512-u45jAyusqUpyGbFc2IbHoeE4rSkoBWQgLe/w99temHenX+GyCz4nflU5sjK7ajU1ffZTezl6le7u43Yjr/lkQg==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4401,13 +4376,6 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
-
-klaw@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.1.1.tgz#42b76894701169cc910fd0d19ce677b5fb378af1"
-  integrity sha1-QrdolHARacyRD9DRnOZ3tfs3ivE=
-  dependencies:
-    graceful-fs "^4.1.9"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -4505,16 +4473,6 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.clone@4.5.0, lodash.clone@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-  integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4551,11 +4509,6 @@ long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
-long@~3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
-  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -4903,21 +4856,21 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nano@^6.4.4:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/nano/-/nano-6.4.4.tgz#4902a095e5186cfb23612c78826ea755b76fadf0"
-  integrity sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==
+nano@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/nano/-/nano-8.2.2.tgz#4fdd48965cece51892cf41e78d433d1b772e6e40"
+  integrity sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==
   dependencies:
-    cloudant-follow "~0.17.0"
-    debug "^2.2.0"
+    "@types/request" "^2.48.4"
+    cloudant-follow "^0.18.2"
+    debug "^4.1.1"
     errs "^0.3.2"
-    lodash.isempty "^4.4.0"
-    request "^2.85.0"
+    request "^2.88.0"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -5028,22 +4981,6 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-pre-gyp@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -5303,11 +5240,6 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
-
-optjs@~3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
-  integrity sha1-aabOicRCpEQDFBrS+bNwvVu29O4=
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -5678,15 +5610,24 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-protobufjs@5.0.3, protobufjs@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
-  integrity sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==
+protobufjs@^6.8.6, protobufjs@^6.9.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
+  integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
   dependencies:
-    ascli "~1"
-    bytebuffer "~5"
-    glob "^7.0.5"
-    yargs "^3.10.0"
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" "^13.7.0"
+    long "^4.0.0"
 
 protobufjs@~6.8.8:
   version "6.8.8"
@@ -5738,11 +5679,6 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5762,11 +5698,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -5867,7 +5798,7 @@ read-pkg@^5.0.0, read-pkg@^5.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5969,32 +5900,6 @@ request-promise-native@^1.0.5:
     request-promise-core "1.1.2"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
-
-request@^2.83.0, request@^2.85.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
@@ -6132,7 +6037,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -6710,20 +6615,7 @@ taketalk@^1.0.0:
     get-stdin "^4.0.1"
     minimist "^1.1.0"
 
-tar-stream@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
-  integrity sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==
-  dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.1.0"
-    end-of-stream "^1.0.0"
-    fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.0"
-    xtend "^4.0.0"
-
-tar@^4, tar@^4.4.2:
+tar@^4:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -6810,11 +6702,6 @@ tmpl@1.0.x:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
-to-buffer@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
-  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -6850,7 +6737,7 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
+tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
@@ -7076,14 +6963,6 @@ url-to-options@^1.0.1:
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -7101,13 +6980,6 @@ util.promisify@^1.0.0:
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -7366,7 +7238,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
@@ -7447,7 +7319,7 @@ yargs@^14.0.0:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^3.10.0, yargs@^3.19.0:
+yargs@^3.19.0:
   version "3.32.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
   integrity sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=
@@ -7550,7 +7422,7 @@ yeoman-generator@^4.8.2:
     mem-fs-editor "^6.0.0"
     yeoman-environment "^2.9.5"
 
-yn@3.1.1:
+yn@3.1.1, yn@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Ripped out fabric-client as its going away replaced with fabric-network.
Added support for private data.
Removed the need to specify a peer to connect to as it now uses the network.yaml and or discovery service to reconnect to a new peer.
Added config items for discovery
Chaincode events no longer have a filter its all or nothing on a per channel+chaincodeId basis.
