### PR TITLE
docs: ✏️ Change to official minifab repository

### DIFF
--- a/examples/minifab/README.md
+++ b/examples/minifab/README.md
@@ -1,6 +1,6 @@
 # Simple minifab example
 
-This example uses [minifab](https://github.com/litong01/minifabric).
+This example uses [minifab](https://github.com/hyperledger-labs/minifabric).
 
 This example targets Hyperledger 2.2.
 

--- a/examples/minifab/start.sh
+++ b/examples/minifab/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p vars
-curl -o minifab -sL https://tinyurl.com/twrt8zv && chmod +x minifab
+curl -o minifab -sL https://tinyurl.com/yxa2q6yr && chmod +x minifab
 ./minifab up --fabric-release 2.2
 set -o allexport
 source vars/run/peer1.org0.example.com.env


### PR DESCRIPTION
Change the install step and the link in the README to use the official
minifab tool.