### PR TITLE
chore: 🤖 Upgrade examples to use Splunk 8.1

### DIFF
--- a/examples/minifab/docker-compose.yml
+++ b/examples/minifab/docker-compose.yml
@@ -2,12 +2,12 @@ version: '3'
 services:
     splunk.example.com:
         container_name: splunk.example.com
-        image: splunk/splunk:latest
+        image: splunk/splunk:8.1
         environment:
             - SPLUNK_START_ARGS=--accept-license
             - SPLUNK_PASSWORD=changeme
             - SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000000
-            - SPLUNK_APPS_URL=http://s3.amazonaws.com/splunk-hyperledger/status-indicator-custom-visualization_130.tgz,http://s3.amazonaws.com/splunk-hyperledger/splunk-metrics-workspace_101.tgz,http://s3.amazonaws.com/splunk-hyperledger/fabric/${BRANCH}/splunk-hyperledger-fabric.tgz
+            - SPLUNK_APPS_URL=http://s3.amazonaws.com/splunk-hyperledger/status-indicator-custom-visualization_130.tgz,http://s3.amazonaws.com/splunk-hyperledger/fabric/${BRANCH}/splunk-hyperledger-fabric.tgz
         ports:
             - '8000:8000'
         volumes:

--- a/examples/prometheus-metrics/docker-compose.yml
+++ b/examples/prometheus-metrics/docker-compose.yml
@@ -2,12 +2,12 @@ version: '3'
 services:
     splunk.example.com:
         container_name: splunk.example.com
-        image: splunk/splunk:latest
+        image: splunk/splunk:8.1
         environment:
             - SPLUNK_START_ARGS=--accept-license
             - SPLUNK_PASSWORD=changeme
             - SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000000
-            - SPLUNK_APPS_URL=http://s3.amazonaws.com/splunk-hyperledger/status-indicator-custom-visualization_130.tgz,http://s3.amazonaws.com/splunk-hyperledger/splunk-metrics-workspace_101.tgz,http://s3.amazonaws.com/splunk-hyperledger/fabric/${BRANCH}/splunk-hyperledger-fabric.tgz
+            - SPLUNK_APPS_URL=http://s3.amazonaws.com/splunk-hyperledger/status-indicator-custom-visualization_130.tgz,http://s3.amazonaws.com/splunk-hyperledger/fabric/${BRANCH}/splunk-hyperledger-fabric.tgz
         ports:
             - '8000:8000'
         volumes:


### PR DESCRIPTION
Upgrade examples to use Splunk 8.1, and drop the metrics workspace app
that is now bundled in.