### PR TITLE
JSON output changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "markdown-table": "^1.1.3",
+    "long": "^4.0.0",
     "oclif": "^1.15.2",
     "protobufjs": "~6.8.8",
     "typescript": "^3.7.3"

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,3 +1,5 @@
+import * as Long from 'long';
+
 const isPlainObject = (obj: any): obj is Object =>
     typeof obj === 'object' && Object.prototype.toString.call(obj) === '[object Object]';
 
@@ -12,6 +14,9 @@ export function convertBuffers(obj: Buffer | Object | any | undefined, path: str
         } else {
             return { hex: obj.toString('hex') };
         }
+    }
+    if (isLong(obj)) {
+        return new Long(obj.low, obj.high, obj.unsigned).toString(10);
     }
     if (Array.isArray(obj)) {
         return obj.map((v, i) => convertBuffers(v, [...path, String(i)]));
@@ -46,4 +51,8 @@ export function isLikelyText(buffer: Buffer): boolean {
 
 export function toText(buffer: Buffer): string {
     return buffer.toString('utf-8');
+}
+
+function isLong(obj: any): boolean {
+    return typeof obj.low === 'number' && typeof obj.high === 'number';
 }

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -52,6 +52,11 @@ describe('convertBuffers', () => {
             }
         `);
     });
+
+    it('should convert Longs to strings', () => {
+        expect(convertBuffers({ low: 4, high: 0, unsigned: false })).toMatchInlineSnapshot(`"4"`);
+        expect(convertBuffers({ low: 4, high: 32, unsigned: false })).toMatchInlineSnapshot(`"137438953476"`);
+    });
 });
 
 describe('isLikelyText', () => {


### PR DESCRIPTION
This pull request provides a change to the JSON data that it sent to Splunk over HEC:
* All longs are serialized to Strings.

It is considered a breaking change.