### PR TITLE
fix name of helm release file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,5 +44,5 @@ jobs:
               with:
                   upload_url: ${{ steps.get_release.outputs.upload_url }}
                   asset_path: build/fabric-logger-${{ steps.determine_version.outputs.version }}.tgz
-                  asset_name: fabric-logger-${{ steps.determine_version.outputs.version }}.tgz
+                  asset_name: fabric-logger-helm-${{ steps.determine_version.outputs.version }}.tgz
                   asset_content_type: application/zip


### PR DESCRIPTION
Update the name of the generated helm release file to match what's in the docs