### PR TITLE
fix: 🐛 pull fabric logger defaults into helm template

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Make sure that the peer credentials are stored in the appropriately named secret
 A `network.yaml` configmap will automatically be generated using the secrets and channel details set above. You can deploy via helm:
 
     helm install -n fabric-logger-${PEER_NAME}-${NS} --namespace ${NS} \
+                 -f https://raw.githubusercontent.com/splunk/fabric-logger/master/defaults.fabriclogger.yaml \
                  -f values.yaml -f network.yaml \
                  https://github.com/splunk/fabric-logger/releases/download/v4.2.1/fabric-logger-helm-4.2.1.tgz
 

--- a/helm-chart/fabric-logger/templates/configmap.yaml
+++ b/helm-chart/fabric-logger/templates/configmap.yaml
@@ -55,6 +55,7 @@ data:
         - channelName: {{ .channelName }}
           chaincodeId: {{ .chaincodeId }}
         {{- end }}
+    {{- if .Values.output }}
     output:
       type: {{ .Values.output.type }}
       sourceTypePrefix: {{ .Values.output.sourceTypePrefix | quote }}
@@ -62,14 +63,20 @@ data:
         {{- range $key, $value:= .Values.output.sourcetypes }}
         {{ $key }}: {{ . | quote }}
         {{- end}}
+    {{- end }}
+    {{- if .Values.prometheus }}
     prometheus:
       discovery: {{ .Values.prometheus.discovery }}
       validateCertificate: {{ .Values.prometheus.validateCertificate }}
       port: {{ .Values.prometheus.port | quote }}
       path: {{ .Values.prometheus.path | quote }}
+    {{- end }}
+    {{- if .Values.checkpoint }}
     checkpoint:
       filename: {{ .Values.checkpoint.filename | quote }}
       saveInterval: {{ .Values.checkpoint.saveInterval }}
+    {{- end }}
+    {{- if .Values.hec }}
     hec:
       default:
         defaultMetadata:
@@ -101,3 +108,4 @@ data:
           {{- range $key, $value:= .Values.hec.internal.defaultFields }}
           {{ $key }}: {{ . }}
           {{- end}}
+    {{- end }}

--- a/helm-chart/fabric-logger/templates/configmap.yaml
+++ b/helm-chart/fabric-logger/templates/configmap.yaml
@@ -55,3 +55,49 @@ data:
         - channelName: {{ .channelName }}
           chaincodeId: {{ .chaincodeId }}
         {{- end }}
+    output:
+      type: {{ .Values.output.type }}
+      sourceTypePrefix: {{ .Values.output.sourceTypePrefix | quote }}
+      sourcetypes:
+        {{- range $key, $value:= .Values.output.sourcetypes }}
+        {{ $key }}: {{ . | quote }}
+        {{- end}}
+    prometheus:
+      discovery: {{ .Values.prometheus.discovery }}
+      validateCertificate: {{ .Values.prometheus.validateCertificate }}
+      port: {{ .Values.prometheus.port | quote }}
+      path: {{ .Values.prometheus.path | quote }}
+    checkpoint:
+      filename: {{ .Values.checkpoint.filename | quote }}
+      saveInterval: {{ .Values.checkpoint.saveInterval }}
+    hec:
+      default:
+        defaultMetadata:
+          {{- range $key, $value:= .Values.hec.default.defaultMetadata }}
+          {{ $key }}: {{ . }}
+          {{- end}}
+        flushTime: {{ .Values.hec.default.flushTime }}
+        maxQueueEntries: {{ .Values.hec.default.maxQueueEntries }}
+        maxQueueSize: {{ .Values.hec.default.maxQueueSize }}
+        gzip: {{ .Values.hec.default.gzip }}
+        timeout: {{ .Values.hec.default.timeout }}
+        requestKeepAlive: {{ .Values.hec.default.requestKeepAlive }}
+        validateCertificate: {{ .Values.hec.default.validateCertificate }}
+        maxSockets: {{ .Values.hec.default.maxSockets }}
+        userAgent: {{ .Values.hec.default.userAgent }}
+        multipleMetricFormatEnabled: {{ .Values.hec.default.multipleMetricFormatEnabled }}
+        waitForAvailability: {{ .Values.hec.default.waitForAvailability }}
+        retryWaitTime:
+          {{- range $key, $value:= .Values.hec.default.retryWaitTime }}
+          {{ $key }}: {{ . }}
+          {{- end}}
+      internal:
+        flushTime: {{ .Values.hec.internal.flushTime }}
+        defaultMetadata:
+          {{- range $key, $value:= .Values.hec.internal.defaultMetadata }}
+          {{ $key }}: {{ . }}
+          {{- end}}
+        defaultFields:
+          {{- range $key, $value:= .Values.hec.internal.defaultFields }}
+          {{ $key }}: {{ . }}
+          {{- end}}


### PR DESCRIPTION
We have identified that fabric-logger is, in particular situations, unable to merge and load the configuration defaults.
To alleviate this issue, we will merge the defaults as part of the configuration provided to the fabric-logger container when creating the configMap that will hold the fabric-logger configuration. This has the benefit of creating a complete configuration file with defaults merged in.

However, this is not a satisfactory long term fix - filing #83 for follow up.