### PR TITLE
fix: 🐛 refactor block integrity config, queries, and logs

### DIFF
--- a/defaults.fabriclogger.yaml
+++ b/defaults.fabriclogger.yaml
@@ -9,10 +9,11 @@ output:
     sourceTypePrefix: 'fabric_logger'
     sourcetypes:
         block: 'fabric_logger:block'
+        block_integrity: 'fabric_logger:block_integrity'
         endorser_transaction: 'fabric_logger:endorser_transaction'
         config: 'fabric_logger:config'
         ccevent: 'fabric_logger:ccevent'
-        nodeMetrics: 'fabric:node:metrics'
+        node_metrics: 'fabric:node:metrics'
 prometheus:
     discovery: false
     validateCertificate: false

--- a/src/cliflags.ts
+++ b/src/cliflags.ts
@@ -167,4 +167,12 @@ export const CLI_FLAGS = {
         description:
             'Default path to try for discovered orderers when scraping Prometheus metrics (overrides PROMETHEUS_PATH).',
     }),
+    'integrity-check-enabled': flags.boolean({
+        env: 'INTEGRITY_CHECK_ENABLED',
+        description: 'Whether to perform blockchain integrity checks.',
+    }),
+    'integrity-check-interval': flags.integer({
+        env: 'INTEGRITY_CHECK_INTERVAL',
+        description: 'Number of blocks between integrity checks.',
+    }),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ class Fabriclogger extends Command {
         const output = await createOutput(config, hecClient);
         this.resources.push(output);
 
-        const fabricListener = new FabricListener(checkpoint, config.fabric, output);
+        const fabricListener = new FabricListener(checkpoint, config.fabric, config.integrity, output);
         this.resources.push(fabricListener);
         await fabricListener.initClient();
         await fabricListener.listen();

--- a/src/msgs.ts
+++ b/src/msgs.ts
@@ -7,7 +7,7 @@ export interface BlockMessage {
 }
 
 export interface BlockIntegrityMessage {
-    type: 'blockIntegrity';
+    type: 'block_integrity';
     response_index: number;
     block_number: number;
     channel: string;
@@ -28,7 +28,7 @@ export interface ChaincodeEventMessage extends ContractEvent {
 }
 
 export interface NodeMetricsMessage extends MultiMetrics {
-    type: 'nodeMetrics';
+    type: 'node_metrics';
 }
 export interface UnKnownMessage extends BlockData {
     type: string;

--- a/src/output.ts
+++ b/src/output.ts
@@ -53,9 +53,9 @@ export class HecOutput implements Output, ManagedResource {
         const event = convertBuffers(message);
         switch (message.type) {
             case 'block':
+            case 'block_integrity':
             case 'endorser_transaction':
             case 'config':
-            case 'ccevent':
                 this.eventsHec.pushEvent({
                     time: timeField ? timeField : new Date(),
                     body: {

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -246,7 +246,7 @@ export class PrometheusEndpointScraper {
             if (this.active) {
                 for (const hecMetrics of convertedMetrics) {
                     this.output.logMultiMetrics({
-                        type: 'nodeMetrics',
+                        type: 'node_metrics',
                         ...hecMetrics,
                     });
                 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -68,14 +68,19 @@ Object {
     },
     "metrics": undefined,
   },
+  "integrity": Object {
+    "enabled": false,
+    "interval": 5,
+  },
   "output": Object {
     "sourceTypePrefix": "fabric_logger",
     "sourcetypes": Object {
       "block": "fabric_logger:block",
+      "block_integrity": "fabric_logger:block_integrity",
       "ccevent": "fabric_logger:ccevent",
       "config": "fabric_logger:config",
       "endorser_transaction": "fabric_logger:endorser_transaction",
-      "nodeMetrics": "fabric:node:metrics",
+      "node_metrics": "fabric:node:metrics",
     },
     "type": "hec",
   },

--- a/test/fabric.test.ts
+++ b/test/fabric.test.ts
@@ -69,7 +69,7 @@ test('fabric', async () => {
     const config = await loadFabricloggerConfig({
         'config-file': './test/config/test.fabriclogger.yaml',
     } as CliFlags);
-    const fabricListener = new FabricListener(checkpoint, config.fabric, output);
+    const fabricListener = new FabricListener(checkpoint, config.fabric, config.integrity, output);
     await fabricListener.initClient();
     await fabricListener.listen({ listenerRetryOptions: { attempts: 1, waitBetween: 0 } });
     expect(fabricListener.hasListener('myChannel')).toBeTruthy();


### PR DESCRIPTION
This PR does the following:
- Adds a config option to enable block integrity checks.
- Only query endorsers belonging to same MSP for block integrity checks.
- Adds responding peers' endorsements and signatures to block integrity check logs.
- Rename variables related to logging for consistency.